### PR TITLE
fix sync write data count issue

### DIFF
--- a/src/instructions/sync_write.rs
+++ b/src/instructions/sync_write.rs
@@ -80,9 +80,9 @@ where
 		T: crate::bus::Data,
 	{
 		let data = data.into_iter();
-		let count = core::mem::size_of::<u8>();
+		let count = T::ENCODED_SIZE;
 		let motors = data.len();
-		let stride = 1 + count;
+		let stride = 1 + count as usize;
 		let parameter_count = 4 + motors * stride;
 		self.write_instruction(packet_id::BROADCAST, instruction_id::SYNC_WRITE, parameter_count, |buffer| {
 			write_u16_le(&mut buffer[0..], address);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,5 @@
 use assert2::{assert, let_assert};
-use dynamixel2::instructions::BulkReadData;
+use dynamixel2::instructions::{BulkReadData, SyncWriteData};
 use test_log::test;
 
 pub mod common;
@@ -33,7 +33,7 @@ fn test_write() {
 #[test]
 fn test_write_bytes() {
 	run(|ids, mut client| {
-		let data = [1, 2, 3, 4];
+		let data = 2000_u32.to_le_bytes();
 		let_assert!(Ok(response) = client.write_bytes(ids[0], 116, &data));
 		assert!(response.motor_id == ids[0]);
 	})
@@ -53,7 +53,7 @@ fn test_reg_write() {
 #[test]
 fn test_reg_write_bytes() {
 	run(|ids, mut client| {
-		let data = [1, 2, 3, 4];
+		let data = 2000_u32.to_le_bytes();
 		let_assert!(Ok(response) = client.reg_write_bytes(ids[0], 116, &data));
 		assert!(response.motor_id == ids[0]);
 	})
@@ -112,6 +112,17 @@ fn test_bulk_read_bytes() {
 				},
 			}
 		}
+	})
+}
+
+#[test]
+fn test_sync_write() {
+	run(|ids, mut client| {
+		let sync_writes = ids.iter().map(|motor_id| SyncWriteData {
+			motor_id: 0,
+			data: 2000_u32
+		});
+		let_assert!(Ok(_) = client.sync_write(116, sync_writes));
 	})
 }
 


### PR DESCRIPTION
Another small pr sorry. Discovered the sync_write function doesn't work as we missed changing the count to the new `T::ENCODED_SIZE`.

Also added a test that would have caught the error.

- **fix incorrect data count in sync_write method**
- **add sync_write test, fix write_bytes, reg_write_bytes data out of range**
